### PR TITLE
Update the UEI: p2p use case layer 2 config with the cred/ and on_cred/ rules.

### DIFF
--- a/api/uei:p2p_trading.yaml
+++ b/api/uei:p2p_trading.yaml
@@ -818,6 +818,63 @@ paths:
                     $ref: '#/components/schemas/Error'
                 required:
                   - message
+  /cred:
+    post:
+      tags:
+        - Beckn Provider Platform (BPP)
+      description: Request for credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    proofs:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/CredentialRequest'
+                  required:
+                    - proofs
+              required:
+                - context
+                - message
+      responses:
+        '200':
+          description: Acknowledgement of message received after successful validation of schema and signature
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        allOf:
+                          - $ref: '#/components/schemas/Ack'
+                          - properties:
+                              status:
+                                enum:
+                                  - ACK
+                                  - NACK
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
   /on_search:
     post:
       tags:
@@ -1985,6 +2042,64 @@ paths:
                     $ref: '#/components/schemas/Error'
                 required:
                   - message
+  /on_cred:
+    post:
+      tags:
+        - Beckn Application Platform (BAP)
+      description: Callback for a credential request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  allOf:
+                    - $ref: '#/components/schemas/Context'
+                    - properties:
+                        action:
+                          enum:
+                            - on_cred
+                      required:
+                        - action
+                message:
+                  type: object
+                  properties:
+                    proofs:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/Credential'
+                  required:
+                    - proofs
+                error:
+                  $ref: '#/components/schemas/Error'
+              required:
+                - context
+      responses:
+        '200':
+          description: Acknowledgement of message received after successful validation of schema and signature
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: object
+                    properties:
+                      ack:
+                        allOf:
+                          - $ref: '#/components/schemas/Ack'
+                          - properties:
+                              status:
+                                enum:
+                                  - ACK
+                                  - NACK
+                    required:
+                      - ack
+                  error:
+                    $ref: '#/components/schemas/Error'
+                required:
+                  - message
 components:
   securitySchemes:
     SubscriberAuth:
@@ -2337,6 +2452,8 @@ components:
         ttl:
           description: The duration in ISO8601 format after timestamp for which this message holds valid
           type: string
+        verified:
+          type: boolean
       required:
           - action
           - domain
@@ -2358,19 +2475,50 @@ components:
           type: string
           description: Country code as per ISO 3166-1 and ISO 3166-2 format
     Credential:
-      description: Describes a credential of an entity - Person or Organization
+      description: 'Describes a credential of an entity - Person, Organization, Item, Payment etc'
       type: object
-      additionalProperties: false
       properties:
         id:
           type: string
         type:
           type: string
-          default: VerifiableCredential
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        docs:
+          description: The Documents associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        media:
+          description: The Media associated with the credential.
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaFile'
         url:
           description: URL of the credential
           type: string
           format: uri
+        verifiableCredential:
+          $ref: '#/components/schemas/VC'
+    CredentialRequest:
+      description: Describes the schema used to request for a proof from an entity
+      type: object
+      properties:
+        credential_purpose:
+          type: object
+          properties:
+            purpose:
+              $ref: '#/components/schemas/Descriptor'
+            document_examples:
+              type: string
+          required:
+            - purpose
+            - document_examples
+        xinput:
+          description: A requester can send a form which can be filled by the sender with relevant details.
+          $ref: '#/components/schemas/XInput'
+      required:
+        - credential_purpose
     Customer:
       description: Describes a customer buying/availing a product or a service
       type: object
@@ -2416,6 +2564,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Image'
+    Document:
+      description: Describes a document which can be sent as a url
+      type: object
+      properties:
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        url:
+          type: string
+          format: uri
+        mime_type:
+          description: 'Describes the contents of the uri field. If the value is text/html, it is recommended for the BAP to render the contents inside a webview. This generally does not render a good user experience on the BAP, hence the payment page developers are recommended to develop their payment pages in a mobile-friendly manner.'
+          type: string
+          enum:
+            - application/pdf
+            - text/plain
+            - image/jpeg
+            - video/mp4
+            - audio/wav
+            - application/zip
     Domain:
       description: "Described the industry sector or sub-sector. The network policy should contain codes for all the industry sectors supported by the network. Domains can be created in varying levels of granularity. The granularity of a domain can be decided by the participants of the network. Too broad domains will result in irrelevant search broadcast calls to BPPs that don't have services supporting the domain. Too narrow domains will result in a large number of registry entries for each BPP. It is recommended that network facilitators actively collaborate with various working groups and network participants to carefully choose domain codes keeping in mind relevance, performance, and opportunity cost. It is recommended that networks choose broad domains like mobility, logistics, healthcare etc, and progressively granularize them as and when the number of network participants for each domain grows large."
       type: object
@@ -3673,6 +3840,106 @@ components:
           enum:
             - ACTIVE
             - INACTIVE
+    VC:
+      description: Describes a Verifiable Credential
+      type: object
+      properties:
+        id:
+          description: 'A unique identifier for the credential (e.g., UUID or URI).'
+          type: string
+        type:
+          description: 'Type of the credential. Its defined as an array to handle cases where a credential falls under multiple types. for example, VerifiableCredential, OpenBadgeCredential.'
+          type: array
+          items:
+            type: string
+        description:
+          $ref: '#/components/schemas/Descriptor'
+        issuer:
+          type: object
+          description: Entity that issued the credential
+          properties:
+            description:
+              $ref: '#/components/schemas/Descriptor'
+            address:
+              $ref: '#/components/schemas/Address'
+            state:
+              $ref: '#/components/schemas/State'
+            city:
+              $ref: '#/components/schemas/City'
+            contact:
+              $ref: '#/components/schemas/Contact'
+            registration_number:
+              type: string
+              description: 'The registration number of the organization, if applicable.'
+            website:
+              type: string
+              format: uri
+              description: The official website of the issuing organization.
+        issueDate:
+          type: string
+          format: date-time
+          description: The date when the credential was issued.
+        validFrom:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        validUntil:
+          type: string
+          format: date-time
+          description: 'The expiration date of the credential, if applicable.'
+        credentialSubject:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+              description:
+                $ref: '#/components/schemas/Descriptor'
+              tags:
+                $ref: '#/components/schemas/TagGroup'
+        claims:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        proof:
+          type: object
+          description: Cryptographic proof of the credential's authenticity
+          properties:
+            created:
+              type: string
+              format: date-time
+              description: Timestamp of when the proof was generated
+            proofPurpose:
+              type: string
+              description: 'This describes the intent of the proof. For example, it could indicate that the proof is used for asserting a particular claim about the credential or verifying its authenticity.'
+            type:
+              type: string
+              description: 'This indicates the specific algorithm or method used for the cryptographic proof (e.g., Ed25519Signature2018). It tells the verifier which cryptographic approach to use when verifying the proof.'
+            verificationMethod:
+              type: string
+              description: This specifies how the proof can be verified. It may include references to public keys or other mechanisms that a verifier would need to validate the proof.
+            proofValue:
+              type: string
+              description: This contains the actual cryptographic signature or value that represents the proof. It's the output of the cryptographic process that will be checked against the claims and the verification method to confirm authenticity.
+        termsOfUse:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+        credentialStatus:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagGroup'
+      required:
+        - id
+        - type
+        - issuer
+        - validUntil
+        - credentialSubject
+        - proof
     Vehicle:
       description: 'Describes a vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space.<br>This has properties like category, capacity, make, model, size,variant,color,energy_type,registration'
       type: object

--- a/examples/ev-charging/cred/cred-request.json
+++ b/examples/ev-charging/cred/cred-request.json
@@ -1,0 +1,36 @@
+{
+    "context": {
+      "domain": "uei:p2p-trading",
+      "action": "on_cred",
+      "location": {
+        "country": {
+          "name": "India",
+          "code": "IND"
+        }
+      },
+      "city": "std:080",
+      "version": "1.1.0",
+      "bap_id": "example-bap.com",
+      "bap_uri": "https://api.example-bap.com/pilot/bap/energy/v1",
+      "bpp_id": "example-energy-bpp.com",
+      "bpp_uri": "https://api.example-bpp.com/pilot/bpp/",
+      "transaction_id": "6743e9e2-4fb5-487c-92b7-13ba8018f176",
+      "message_id": "6743e9e2-4fb5-487c-92b7-13ba8018f176",
+      "timestamp": "2023-07-16T04:41:16Z",
+      "verified": true
+    },
+    "message": {
+      "proofs": [
+        {
+          "credential_purpose": {
+            "purpose": {
+              "name": "Proof of green energy",
+              "code": "GREEN_ENERGY_PROOF",
+              "short_desc": "Want to check if the seller is actually selling green energy"
+            },
+            "document_examples": "Documents like Renewable Energy Certificates (RECs), Guarantees of Origin (GOs) etc"
+          }
+        }
+      ]
+    }
+  }

--- a/examples/ev-charging/cred/on_cred-request.json
+++ b/examples/ev-charging/cred/on_cred-request.json
@@ -1,0 +1,64 @@
+{
+    "context": {
+      "domain": "uei:p2p-trading",
+      "action": "on_cred",
+      "location": {
+        "country": {
+          "name": "India",
+          "code": "IND"
+        }
+      },
+      "city": "std:080",
+      "version": "1.1.0",
+      "bap_id": "example-bap.com",
+      "bap_uri": "https://api.example-bap.com/pilot/bap/energy/v1",
+      "bpp_id": "example-energy-bpp.com",
+      "bpp_uri": "https://api.example-bpp.com/pilot/bpp/",
+      "transaction_id": "6743e9e2-4fb5-487c-92b7-13ba8018f176",
+      "message_id": "6743e9e2-4fb5-487c-92b7-13ba8018f176",
+      "timestamp": "2023-07-16T04:41:16Z",
+      "verified": true
+    },
+    "message": {
+      "proofs": [
+        {
+          "verifiableCredential": {
+            "id": "http://example.gov/credentials/3732",
+            "type": ["VerifiableCredential", "ExampleGreenEnergyCredential"],
+            "issuer": {
+              "description": {
+                "name": "did:example:6fb1f712ebe12c27cc26eebfe11"
+              }
+            },
+            "issueDate": "2022-01-01T19:23:24Z",
+            "validFrom": "2022-01-01T19:23:24Z",
+            "validUntil": "2027-01-01T19:23:24Z",
+            "credentialSubject": {
+              "id": "https://subject.example/subject/3921",
+              "tags": [
+                {
+                  "descriptor":{
+                    "name": "ExampleGreenEnergyCredential"
+                  },
+                  "list": [
+                    {
+  
+                      "value": "Renewable Energy Guarantees of Origin"
+                    }
+                  ]
+                }
+              ]
+            },
+            "proof": {
+              "type": "DataIntegrityProof",
+              "created": "2022-11-13T18:19:39Z",
+              "verificationMethod": "did:key:zDnaeyJCMXfq8SgtJWbcLgaJyDGY8BU6iw8rhMyqC4aYumkRu",
+              "cryptosuite": "eddsa-rdfc-2022",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "z5aDaMUdSGSrAarqQCwPEbLbDTvXt2yQGeYyViiVwgWCQ14iNgXqkSWC72uVBW4Vz2y2NdNy9dvnSZkRCSNqJ7HgN"
+            }
+          }
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
### Description
As part of enhancing trust in Beckn transaction flow, 2 new endpoints, cred/ and on_cred/ were created.

In this PR we are adding network rules related to Credential in the UEI p2p layer 2 configuration.

### Changes

1. All the changes are done in api/uei:p2p_trading.yaml file.
2. Added the two new endpoints, cred/ and on_cred/
3. Added VC schema.
4. Added CredentialRequest schema.
5. Embedded VC schema inside Credential schema.
6. Updated Context Schema to have a verified field.
7. Added network rules in the Credential schema.
8. Added Document schema, which is used in the Credential schema.

### Other Changes
In addition to the above changes, example jsons for cred/ and on_cred/ APIs were also added in the examples folder.